### PR TITLE
change background-color --> background

### DIFF
--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -80,7 +80,7 @@ export const getStyles = ({
 
 	const baseStyles = {
 		'object-fit': objectFit,
-		'background-color': placeholder || 'transparent',
+		background: placeholder || 'transparent',
 	};
 
 	switch (layout) {


### PR DESCRIPTION
## This change gives more flexibility

<img width="450" alt="Screenshot 2023-03-08 at 13 41 11" src="https://user-images.githubusercontent.com/35845425/223716084-69e94109-c2cf-4b2b-b483-420d9cafa331.png">

## Use cases: 

#### `background: 'rgba(37,99,235,1)';`

<img width="317" alt="Screenshot 2023-03-08 at 13 39 18" src="https://user-images.githubusercontent.com/35845425/223715512-d097de71-09a8-4e55-aa54-f59850e0a3a3.png">

#### `background: 'linear-gradient(180deg, rgba(2,0,36,1) 0%, rgba(166,206,247,1) 0%, rgba(37,99,235,1) 83%);';`

<img width="312" alt="Screenshot 2023-03-08 at 13 37 43" src="https://user-images.githubusercontent.com/35845425/223715243-a058998c-f2c3-4811-b15d-344d3fd3a891.png">

#### `background: 'url("/public/placeholder.jpg") no-repeat center / cover';`

<img width="320" alt="Screenshot 2023-03-08 at 13 38 23" src="https://user-images.githubusercontent.com/35845425/223715374-ea5a41fa-a7df-42e1-af1b-2c0322608397.png">

@tleperou what do you think?
